### PR TITLE
Convert rewrite subcommand help summaries to use third-person singular verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-cli/rewrite-command
 ======================
 
-Manage rewrite rules.
+Lists or flushes the site's rewrite rules, updates the permalink structure.
 
 [![Build Status](https://travis-ci.org/wp-cli/rewrite-command.svg?branch=master)](https://travis-ci.org/wp-cli/rewrite-command)
 
@@ -11,9 +11,41 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 
 This package implements the following commands:
 
+### wp rewrite
+
+Lists or flushes the site's rewrite rules, updates the permalink structure.
+
+~~~
+wp rewrite
+~~~
+
+See the WordPress [Rewrite API](https://codex.wordpress.org/Rewrite_API) and 
+[WP Rewrite](https://codex.wordpress.org/Class_Reference/WP_Rewrite) class reference.
+
+**EXAMPLES**
+
+    # Flush rewrite rules
+    $ wp rewrite flush
+    Success: Rewrite rules flushed.
+
+    # Update permalink structure
+    $ wp rewrite structure '/%year%/%monthnum%/%postname%'
+    Success: Rewrite structure set.
+
+    # List rewrite rules
+    $ wp rewrite list --format=csv
+    match,query,source
+    ^wp-json/?$,index.php?rest_route=/,other
+    ^wp-json/(.*)?,index.php?rest_route=/$matches[1],other
+    category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$,index.php?category_name=$matches[1]&feed=$matches[2],category
+    category/(.+?)/(feed|rdf|rss|rss2|atom)/?$,index.php?category_name=$matches[1]&feed=$matches[2],category
+    category/(.+?)/embed/?$,index.php?category_name=$matches[1]&embed=true,category
+
+
+
 ### wp rewrite flush
 
-Flush rewrite rules.
+Flushes rewrite rules.
 
 ~~~
 wp rewrite flush [--hard]
@@ -43,7 +75,7 @@ apache_modules:
 
 ### wp rewrite list
 
-Get a list of the current rewrite rules.
+Gets a list of the current rewrite rules.
 
 ~~~
 wp rewrite list [--match=<url>] [--source=<source>] [--fields=<fields>] [--format=<format>]
@@ -86,7 +118,7 @@ wp rewrite list [--match=<url>] [--source=<source>] [--fields=<fields>] [--forma
 
 ### wp rewrite structure
 
-Update the permalink structure.
+Updates the permalink structure.
 
 ~~~
 wp rewrite structure <permastruct> [--category-base=<base>] [--tag-base=<base>] [--hard]

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/rewrite-command",
-    "description": "Manage rewrite rules.",
+    "description": "Lists or flushes the site's rewrite rules, updates the permalink structure.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/rewrite-command",
     "support": {
@@ -34,6 +34,7 @@
             "dev-master": "1.x-dev"
         },
         "commands": [
+            "rewrite",
             "rewrite flush",
             "rewrite list",
             "rewrite structure"

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -30,7 +30,7 @@
 class Rewrite_Command extends WP_CLI_Command {
 
 	/**
-	 * Flush rewrite rules.
+	 * Flushes rewrite rules.
 	 *
 	 * Resets WordPress' rewrite rules based on registered post types, etc.
 	 *
@@ -76,7 +76,7 @@ class Rewrite_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Update the permalink structure.
+	 * Updates the permalink structure.
 	 *
 	 * Sets the post permalink structure to the specified pattern.
 	 *
@@ -170,7 +170,7 @@ class Rewrite_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get a list of the current rewrite rules.
+	 * Gets a list of the current rewrite rules.
 	 *
 	 * ## OPTIONS
 	 *
@@ -275,7 +275,7 @@ class Rewrite_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Expose apache modules if present in config
+	 * Exposes apache modules if present in config
 	 *
 	 * Implementation Notes: This function exposes a global function
 	 * apache_get_modules and also sets the $is_apache global variable.
@@ -315,7 +315,7 @@ class Rewrite_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Display a warning if --skip-plugins or --skip-themes are in use.
+	 * Displays a warning if --skip-plugins or --skip-themes are in use.
 	 *
 	 * Skipping the loading of plugins or themes can mean some rewrite rules
 	 * are unregistered, which may cause erroneous behavior.


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for rewrite subcommands to use third-person singular verbs.