### PR TITLE
Apply PHPCS `WP_CLI_CS` rules

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 *.tar.gz
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,4 +51,9 @@
 		</properties>
 	</rule>
 
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/Rewrite_Command\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-rewrite">
+	<description>Custom ruleset for WP-CLI rewrite-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Rewrite"/><!-- Namespaces. -->
+				<element value="wpcli_rewrite"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/rewrite-command.php
+++ b/rewrite-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$wpcli_rewrite_autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $wpcli_rewrite_autoload ) ) {
-	require_once $wpcli_rewrite_autoload;
+$wpcli_rewrite_autoloader = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_rewrite_autoloader ) ) {
+	require_once $wpcli_rewrite_autoloader;
 }
 
 WP_CLI::add_command( 'rewrite', 'Rewrite_Command' );

--- a/rewrite-command.php
+++ b/rewrite-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$wpcli_rewrite_autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_rewrite_autoload ) ) {
+	require_once $wpcli_rewrite_autoload;
 }
 
 WP_CLI::add_command( 'rewrite', 'Rewrite_Command' );

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -27,6 +27,7 @@
  *
  * @package wp-cli
  */
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- for back compat this class shouldn't be renamed.
 class Rewrite_Command extends WP_CLI_Command {
 
 	/**

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -114,17 +114,19 @@ class Rewrite_Command extends WP_CLI_Command {
 		// copypasta from /wp-admin/options-permalink.php
 
 		$prefix = $blog_prefix = '';
-		if ( is_multisite() && !is_subdomain_install() && is_main_site() )
+		if ( is_multisite() && !is_subdomain_install() && is_main_site() ) {
 			$blog_prefix = '/blog';
+		}
 
 		$permalink_structure = ( $args[0] == 'default' ) ? '' : $args[0];
 
 		if ( ! empty( $permalink_structure ) ) {
 			$permalink_structure = preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $permalink_structure ) );
-			if ( $prefix && $blog_prefix )
+			if ( $prefix && $blog_prefix ) {
 				$permalink_structure = $prefix . preg_replace( '#^/?index\.php#', '', $permalink_structure );
-			else
+			} else {
 				$permalink_structure = $blog_prefix . $permalink_structure;
+			}
 		}
 		$wp_rewrite->set_permalink_structure( $permalink_structure );
 
@@ -132,16 +134,18 @@ class Rewrite_Command extends WP_CLI_Command {
 		if ( isset( $assoc_args['category-base'] ) ) {
 
 			$category_base = $assoc_args['category-base'];
-			if ( ! empty( $category_base ) )
+			if ( ! empty( $category_base ) ) {
 				$category_base = $blog_prefix . preg_replace('#/+#', '/', '/' . str_replace( '#', '', $category_base ) );
+			}
 			$wp_rewrite->set_category_base( $category_base );
 		}
 
 		if ( isset( $assoc_args['tag-base'] ) ) {
 
 			$tag_base = $assoc_args['tag-base'];
-			if ( ! empty( $tag_base ) )
+			if ( ! empty( $tag_base ) ) {
 				$tag_base = $blog_prefix . preg_replace('#/+#', '/', '/' . str_replace( '#', '', $tag_base ) );
+			}
 			$wp_rewrite->set_tag_base( $tag_base );
 		}
 
@@ -247,16 +251,18 @@ class Rewrite_Command extends WP_CLI_Command {
 		// Apply the filters used in core just in case
 		foreach( $rewrite_rules_by_source as $source => $source_rules ) {
 			$rewrite_rules_by_source[$source] = apply_filters( $source . '_rewrite_rules', $source_rules );
-			if ( 'post_tag' == $source )
-				$rewrite_rules_by_source[$source] = apply_filters( 'tag_rewrite_rules', $source_rules );
+			if ( 'post_tag' == $source ) {
+				$rewrite_rules_by_source[ $source ] = apply_filters( 'tag_rewrite_rules', $source_rules );
+			}
 		}
 
 		$rule_list = array();
 		foreach ( $rules as $match => $query ) {
 
 			if ( ! empty( $assoc_args['match'] )
-				&& ! preg_match( "!^$match!", trim( $assoc_args['match'], '/' ) ) )
-				continue;
+				&& ! preg_match( "!^$match!", trim( $assoc_args['match'], '/' ) ) ) {
+					continue;
+				}
 
 			$source = 'other';
 			foreach( $rewrite_rules_by_source as $rules_source => $source_rules ) {
@@ -265,8 +271,9 @@ class Rewrite_Command extends WP_CLI_Command {
 				}
 			}
 
-			if ( ! empty( $assoc_args['source'] ) && $source != $assoc_args['source'] )
+			if ( ! empty( $assoc_args['source'] ) && $source != $assoc_args['source'] ) {
 				continue;
+			}
 
 			$rule_list[] = compact( 'match', 'query', 'source' );
 		}

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -113,12 +113,12 @@ class Rewrite_Command extends WP_CLI_Command {
 
 		// copypasta from /wp-admin/options-permalink.php
 
-		$prefix = $blog_prefix = '';
+		$prefix = $blog_prefix = ''; // phpcs:ignore
 		if ( is_multisite() && ! is_subdomain_install() && is_main_site() ) {
 			$blog_prefix = '/blog';
 		}
 
-		$permalink_structure = ( $args[0] == 'default' ) ? '' : $args[0];
+		$permalink_structure = ( 'default' == $args[0] ) ? '' : $args[0];
 
 		if ( ! empty( $permalink_structure ) ) {
 			$permalink_structure = preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $permalink_structure ) );

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -311,6 +311,7 @@ class Rewrite_Command extends WP_CLI_Command {
 		$mods = WP_CLI::get_config( 'apache_modules' );
 		if ( ! empty( $mods ) && ! function_exists( 'apache_get_modules' ) ) {
 			global $is_apache;
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$is_apache = true;
 
 			// needed for get_home_path() and .htaccess location

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -114,7 +114,7 @@ class Rewrite_Command extends WP_CLI_Command {
 		// copypasta from /wp-admin/options-permalink.php
 
 		$prefix = $blog_prefix = '';
-		if ( is_multisite() && !is_subdomain_install() && is_main_site() ) {
+		if ( is_multisite() && ! is_subdomain_install() && is_main_site() ) {
 			$blog_prefix = '/blog';
 		}
 
@@ -135,7 +135,7 @@ class Rewrite_Command extends WP_CLI_Command {
 
 			$category_base = $assoc_args['category-base'];
 			if ( ! empty( $category_base ) ) {
-				$category_base = $blog_prefix . preg_replace('#/+#', '/', '/' . str_replace( '#', '', $category_base ) );
+				$category_base = $blog_prefix . preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $category_base ) );
 			}
 			$wp_rewrite->set_category_base( $category_base );
 		}
@@ -144,7 +144,7 @@ class Rewrite_Command extends WP_CLI_Command {
 
 			$tag_base = $assoc_args['tag-base'];
 			if ( ! empty( $tag_base ) ) {
-				$tag_base = $blog_prefix . preg_replace('#/+#', '/', '/' . str_replace( '#', '', $tag_base ) );
+				$tag_base = $blog_prefix . preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $tag_base ) );
 			}
 			$wp_rewrite->set_tag_base( $tag_base );
 		}
@@ -157,9 +157,9 @@ class Rewrite_Command extends WP_CLI_Command {
 		// Launch a new process to flush rewrites because core expects flush
 		// to happen after rewrites are set
 		$new_assoc_args = array();
-		$cmd = 'rewrite flush';
+		$cmd            = 'rewrite flush';
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) ) {
-			$cmd .= ' --hard';
+			$cmd                   .= ' --hard';
 			$new_assoc_args['hard'] = true;
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
 				WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
@@ -222,7 +222,7 @@ class Rewrite_Command extends WP_CLI_Command {
 
 		self::check_skip_plugins_themes();
 
-		$defaults = array(
+		$defaults   = array(
 			'source' => '',
 			'match'  => '',
 			'format' => 'table',
@@ -230,27 +230,27 @@ class Rewrite_Command extends WP_CLI_Command {
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
-		$rewrite_rules_by_source = array();
-		$rewrite_rules_by_source['post'] = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->permalink_structure, EP_PERMALINK );
-		$rewrite_rules_by_source['date'] = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->get_date_permastruct(), EP_DATE );
-		$rewrite_rules_by_source['root'] = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->root . '/', EP_ROOT );
+		$rewrite_rules_by_source             = array();
+		$rewrite_rules_by_source['post']     = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->permalink_structure, EP_PERMALINK );
+		$rewrite_rules_by_source['date']     = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->get_date_permastruct(), EP_DATE );
+		$rewrite_rules_by_source['root']     = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->root . '/', EP_ROOT );
 		$rewrite_rules_by_source['comments'] = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->root . $wp_rewrite->comments_base, EP_COMMENTS, true, true, true, false );
-		$rewrite_rules_by_source['search'] = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->get_search_permastruct(), EP_SEARCH );
-		$rewrite_rules_by_source['author'] = $wp_rewrite->generate_rewrite_rules($wp_rewrite->get_author_permastruct(), EP_AUTHORS );
-		$rewrite_rules_by_source['page'] = $wp_rewrite->page_rewrite_rules();
+		$rewrite_rules_by_source['search']   = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->get_search_permastruct(), EP_SEARCH );
+		$rewrite_rules_by_source['author']   = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->get_author_permastruct(), EP_AUTHORS );
+		$rewrite_rules_by_source['page']     = $wp_rewrite->page_rewrite_rules();
 
 		// Extra permastructs including tags, categories, etc.
 		foreach ( $wp_rewrite->extra_permastructs as $permastructname => $permastruct ) {
 			if ( is_array( $permastruct ) ) {
-				$rewrite_rules_by_source[$permastructname] = $wp_rewrite->generate_rewrite_rules( $permastruct['struct'], $permastruct['ep_mask'], $permastruct['paged'], $permastruct['feed'], $permastruct['forcomments'], $permastruct['walk_dirs'], $permastruct['endpoints'] );
+				$rewrite_rules_by_source[ $permastructname ] = $wp_rewrite->generate_rewrite_rules( $permastruct['struct'], $permastruct['ep_mask'], $permastruct['paged'], $permastruct['feed'], $permastruct['forcomments'], $permastruct['walk_dirs'], $permastruct['endpoints'] );
 			} else {
-				$rewrite_rules_by_source[$permastructname] = $wp_rewrite->generate_rewrite_rules( $permastruct, EP_NONE );
+				$rewrite_rules_by_source[ $permastructname ] = $wp_rewrite->generate_rewrite_rules( $permastruct, EP_NONE );
 			}
 		}
 
 		// Apply the filters used in core just in case
-		foreach( $rewrite_rules_by_source as $source => $source_rules ) {
-			$rewrite_rules_by_source[$source] = apply_filters( $source . '_rewrite_rules', $source_rules );
+		foreach ( $rewrite_rules_by_source as $source => $source_rules ) {
+			$rewrite_rules_by_source[ $source ] = apply_filters( $source . '_rewrite_rules', $source_rules );
 			if ( 'post_tag' == $source ) {
 				$rewrite_rules_by_source[ $source ] = apply_filters( 'tag_rewrite_rules', $source_rules );
 			}
@@ -259,13 +259,12 @@ class Rewrite_Command extends WP_CLI_Command {
 		$rule_list = array();
 		foreach ( $rules as $match => $query ) {
 
-			if ( ! empty( $assoc_args['match'] )
-				&& ! preg_match( "!^$match!", trim( $assoc_args['match'], '/' ) ) ) {
-					continue;
-				}
+			if ( ! empty( $assoc_args['match'] ) && ! preg_match( "!^$match!", trim( $assoc_args['match'], '/' ) ) ) {
+				continue;
+			}
 
 			$source = 'other';
-			foreach( $rewrite_rules_by_source as $rules_source => $source_rules ) {
+			foreach ( $rewrite_rules_by_source as $rules_source => $source_rules ) {
 				if ( array_key_exists( $match, $source_rules ) ) {
 					$source = $rules_source;
 				}
@@ -307,8 +306,8 @@ class Rewrite_Command extends WP_CLI_Command {
 	 * to disk.
 	 */
 	private static function apache_modules() {
-		$mods = WP_CLI::get_config('apache_modules');
-		if ( !empty( $mods ) && !function_exists( 'apache_get_modules' ) ) {
+		$mods = WP_CLI::get_config( 'apache_modules' );
+		if ( ! empty( $mods ) && ! function_exists( 'apache_get_modules' ) ) {
 			global $is_apache;
 			$is_apache = true;
 

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -113,7 +113,8 @@ class Rewrite_Command extends WP_CLI_Command {
 
 		// copypasta from /wp-admin/options-permalink.php
 
-		$prefix = $blog_prefix = ''; // phpcs:ignore
+		$blog_prefix = '';
+		$prefix      = $blog_prefix;
 		if ( is_multisite() && ! is_subdomain_install() && is_main_site() ) {
 			$blog_prefix = '/blog';
 		}

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -288,7 +288,7 @@ class Rewrite_Command extends WP_CLI_Command {
 	 * apache_get_modules and also sets the $is_apache global variable.
 	 *
 	 * This is so that flush_rewrite_rules will actually write out the
-	 * .htaccess file for apache wordpress installations. There is a check
+	 * .htaccess file for apache WordPress installations. There is a check
 	 * to see:
 	 *
 	 * 1. if the $is_apache variable is set.

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -250,8 +250,10 @@ class Rewrite_Command extends WP_CLI_Command {
 
 		// Apply the filters used in core just in case
 		foreach ( $rewrite_rules_by_source as $source => $source_rules ) {
+			// phpcs:ignore WordPress.NamingConventions,PrefixAllGlobals.DynamicHooknameFound
 			$rewrite_rules_by_source[ $source ] = apply_filters( $source . '_rewrite_rules', $source_rules );
 			if ( 'post_tag' == $source ) {
+				// phpcs:ignore WordPress.NamingConventions,PrefixAllGlobals.DynamicHooknameFound
 				$rewrite_rules_by_source[ $source ] = apply_filters( 'tag_rewrite_rules', $source_rules );
 			}
 		}

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -57,7 +57,7 @@ class Rewrite_Command extends WP_CLI_Command {
 		self::apache_modules();
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) && ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
-			WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
+			WP_CLI::warning( 'Regenerating a .htaccess file requires special configuration. See usage docs.' );
 		}
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) && is_multisite() ) {
@@ -152,7 +152,7 @@ class Rewrite_Command extends WP_CLI_Command {
 		// make sure we detect mod_rewrite if configured in apache_modules in config
 		self::apache_modules();
 
-		WP_CLI::success( "Rewrite structure set." );
+		WP_CLI::success( 'Rewrite structure set.' );
 
 		// Launch a new process to flush rewrites because core expects flush
 		// to happen after rewrites are set
@@ -162,7 +162,7 @@ class Rewrite_Command extends WP_CLI_Command {
 			$cmd                   .= ' --hard';
 			$new_assoc_args['hard'] = true;
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
-				WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
+				WP_CLI::warning( 'Regenerating a .htaccess file requires special configuration. See usage docs.' );
 			}
 		}
 


### PR DESCRIPTION
This applies various PHPCS fixes based on the new WPCliCS ruleset

The only remaining `WARNING`s here are strict comparisons. I didn't want to touch these as I was unsure what implications that it would have changing them.

```
FILE: /home/williampatton/wd-sw/rewrite-command/src/Rewrite_Command.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 5 WARNINGS AFFECTING 5 LINES
--------------------------------------------------------------------------------
  60 | WARNING | Not using strict comparison for in_array; supply true for
     |         | third argument.
 123 | WARNING | Found: ==. Use strict comparisons (=== or !==).
 166 | WARNING | Not using strict comparison for in_array; supply true for
     |         | third argument.
 257 | WARNING | Found: ==. Use strict comparisons (=== or !==).
 277 | WARNING | Found: !=. Use strict comparisons (=== or !==).
--------------------------------------------------------------------------------

Time: 216ms; Memory: 12MB

```

Part 2 of #31 

Related https://github.com/wp-cli/wp-cli/issues/5179