### PR TITLE
Improve Warning Message in wp rewrite flush

### DIFF
--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -107,14 +107,14 @@ Feature: Manage WordPress rewrites
     When I try `wp --skip-plugins rewrite flush`
     Then STDERR should contain:
       """
-      Warning: Some rewrite rules may be missing because plugins weren't loaded.
+      Warning: Some rewrite rules may be missing because plugins weren't loaded by WP-CLI.
       """
     And the return code should be 0
 
     When I try `wp --skip-plugins --skip-themes rewrite flush`
     Then STDERR should contain:
       """
-      Warning: Some rewrite rules may be missing because plugins and themes weren't loaded.
+      Warning: Some rewrite rules may be missing because plugins and themes weren't loaded by WP-CLI.
       """
     And the return code should be 0
 

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -359,7 +359,7 @@ class Rewrite_Command extends WP_CLI_Command {
 			return;
 		}
 		$skipped = implode( ' and ', $skipped );
-		WP_CLI::warning( sprintf( "Some rewrite rules may be missing because %s weren't loaded.", $skipped ) );
+		WP_CLI::warning( sprintf( "Some rewrite rules may be missing because %s weren't loaded by WP-CLI.", $skipped ) );
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/rewrite-command/issues/70

**Summary**

This PR updates the warning message displayed when running `wp rewrite flush` to provide clearer context on why rewrite rules may be missing. The revised messages explicitly mention WP-CLI's role in loading themes and reference the --skip-themes flag when applicable.

Changes Made

Updated the warning message from:
    
**"Warning: Some rewrite rules may be missing because themes weren't loaded."**
    
to:
    
**"Warning: Some rewrite rules may be missing because themes weren't loaded by WP-CLI."**