### PR TITLE
Removed unused $new_assoc_args variable in wp rewrite structure subcommand

### DIFF
--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -160,11 +160,13 @@ class Rewrite_Command extends WP_CLI_Command {
 
 		// Launch a new process to flush rewrites because core expects flush
 		// to happen after rewrites are set
-		$new_assoc_args = [];
+		
 		$cmd            = 'rewrite flush';
 		if ( Utils\get_flag_value( $assoc_args, 'hard' ) ) {
 			$cmd                   .= ' --hard';
-			$new_assoc_args['hard'] = true;
+			
+			// Check if the 'mod_rewrite' Apache module is enabled. 
+			// If not, display a warning since regenerating the .htaccess file requires this module.
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ), true ) ) {
 				WP_CLI::warning( 'Regenerating a .htaccess file requires special configuration. See usage docs.' );
 			}

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -163,10 +163,8 @@ class Rewrite_Command extends WP_CLI_Command {
 		
 		$cmd            = 'rewrite flush';
 		if ( Utils\get_flag_value( $assoc_args, 'hard' ) ) {
-			$cmd                   .= ' --hard';
+			$cmd .= ' --hard';
 			
-			// Check if the 'mod_rewrite' Apache module is enabled. 
-			// If not, display a warning since regenerating the .htaccess file requires this module.
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ), true ) ) {
 				WP_CLI::warning( 'Regenerating a .htaccess file requires special configuration. See usage docs.' );
 			}

--- a/src/Rewrite_Command.php
+++ b/src/Rewrite_Command.php
@@ -160,11 +160,9 @@ class Rewrite_Command extends WP_CLI_Command {
 
 		// Launch a new process to flush rewrites because core expects flush
 		// to happen after rewrites are set
-		
-		$cmd            = 'rewrite flush';
+		$cmd = 'rewrite flush';
 		if ( Utils\get_flag_value( $assoc_args, 'hard' ) ) {
 			$cmd .= ' --hard';
-			
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ), true ) ) {
 				WP_CLI::warning( 'Regenerating a .htaccess file requires special configuration. See usage docs.' );
 			}


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
Hello Team,

I have reviewed issue #40: Remove unused variable $new_assoc_args in wp rewrite structure subcommand.

After analyzing the code, I found the variable is indeed unused. I have implemented a fix by removing the unused variable from the relevant file.

A pull request has been created with this change.

Thank you!
